### PR TITLE
fix: support promised results in unwrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,18 @@ export const flatMap = <ValueType, NewValue, ErrorType = unknown>(
 	fn: (v: ValueType) => Result<NewValue, ErrorType>,
 ): Result<NewValue, ErrorType> => (r.ok ? fn(r.value) : r)
 
-export const unwrap = <ValueType, ErrorType = unknown>(
+export function unwrap<ValueType, ErrorType = unknown>(
 	r: Result<ValueType, ErrorType>,
-): ValueType => {
+): ValueType
+export function unwrap<ValueType, ErrorType = unknown>(
+	r: PromiseLike<Result<ValueType, ErrorType>>,
+): Promise<ValueType>
+export function unwrap<ValueType, ErrorType = unknown>(
+	r: Result<ValueType, ErrorType> | PromiseLike<Result<ValueType, ErrorType>>,
+): ValueType | Promise<ValueType> {
+	if (isPromiseLike<Result<ValueType, ErrorType>>(r)) {
+		return Promise.resolve(r).then(value => unwrap(value))
+	}
 	if (r.ok) return r.value
 	throw r.error
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -58,6 +58,11 @@ describe("Ok / Err methods", () => {
 		expect(orElse(ok(42), 7)).toBe(42)
 		expect(orElse(err("E"), 7)).toBe(7)
 	})
+
+	test("unwrap promise", async () => {
+		await expect(unwrap(Promise.resolve(ok(42)))).resolves.toBe(42)
+		await expect(unwrap(Promise.resolve(err("E")))).rejects.toBe("E")
+	})
 })
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- support `unwrap` for promised `Result` values
- keep the existing sync `unwrap` behavior unchanged
- add async coverage for promised `Ok` and `Err`

## Testing
- npm test -- --runInBand
- npm run build